### PR TITLE
Implement `reflect`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FactorRotations"
 uuid = "be5e9834-f3d9-4b7e-b5ea-d062861d4ac2"
 authors = ["Philipp Gewessler"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -42,6 +42,8 @@ kaiser_denormalize!
 kaiser_normalize
 kaiser_normalize!
 loadings
+reflect
+reflect!
 rotate
 rotate!
 rotation

--- a/src/FactorRotations.jl
+++ b/src/FactorRotations.jl
@@ -8,7 +8,7 @@ using Logging
 using SimpleUnPack
 using Statistics
 
-import LinearAlgebra: rotate!
+import LinearAlgebra: rotate!, reflect!
 
 export setverbosity!
 
@@ -16,6 +16,8 @@ export FactorRotation, loadings, rotation, factor_correlation
 export rotate, rotate!
 export criterion, criterion_and_gradient
 export ConvergenceError
+
+export reflect, reflect!
 
 export kaiser_normalize, kaiser_denormalize
 export kaiser_normalize!, kaiser_denormalize!
@@ -63,5 +65,6 @@ include("normalize.jl")
 include("rotation_types.jl")
 include("methods/methods.jl")
 include("rotate.jl")
+include("reflect.jl")
 
 end

--- a/src/normalize.jl
+++ b/src/normalize.jl
@@ -34,6 +34,8 @@ julia> weights
 
 julia> L_norm ≈ L
 true
+
+```
 """
 function kaiser_normalize!(Λ::AbstractMatrix)
     weights = communalities(Λ)

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -1,0 +1,71 @@
+"""
+    reflect!(r::FactorRotation)
+
+Modify `r` in-place by swapping signs of the loading matrix `r.L` such that the sum of each
+column is positive. The rotation matrix `r.T` and factor correlation matrix `r.phi` are
+updated accordingly.
+
+## Examples
+```jldoctest
+$(DEFINITION_L)
+
+julia> r = rotate(L, Varimax());
+
+julia> r_reflected = reflect!(r)
+FactorRotation{Float64} with loading matrix:
+8×2 Matrix{Float64}:
+ 0.886061  0.246196
+ 0.924934  0.183253
+ 0.894664  0.155581
+ 0.865205  0.221416
+ 0.264636  0.893176
+ 0.206218  0.786653
+ 0.156572  0.724884
+ 0.269424  0.67595
+
+julia> r == r_reflected
+true
+```
+"""
+function reflect!(r::FactorRotation)
+    @unpack L, T, phi = r
+    v = reflect_cols(L)
+    L .*= v
+    T .*= v
+    phi .= T' * T
+    return r
+end
+
+"""
+    reflect(r::FactorRotation)
+
+Return a new [`FactorRotation`](@ref) with a modified loading matrix such that the sum of
+each column is positive. The rotation matrix and factor correlation matrix are updated
+accordingly.
+
+## Examples
+```jldoctest
+$(DEFINITION_L)
+
+julia> r = rotate(L, Varimax());
+
+julia> reflect(r)
+FactorRotation{Float64} with loading matrix:
+8×2 Matrix{Float64}:
+ 0.886061  0.246196
+ 0.924934  0.183253
+ 0.894664  0.155581
+ 0.865205  0.221416
+ 0.264636  0.893176
+ 0.206218  0.786653
+ 0.156572  0.724884
+ 0.269424  0.67595
+
+```
+"""
+reflect(r::FactorRotation) = reflect!(deepcopy(r))
+
+function reflect_cols(m::AbstractMatrix)
+    colsums = sum(m, dims = 1)
+    return @. ifelse(colsums < 0, -1, 1)
+end

--- a/src/rotate.jl
+++ b/src/rotate.jl
@@ -70,7 +70,9 @@ Perform a rotation of the factor loading matrix `Λ` using a rotation `method`.
                   starting matrices.
                   If `randomstarts = x::Int`, the algorithm is started `x` times from random
                   starting matrices.
-- `verbose`: Print logging statements (default: false)
+- `reflect`: Switch signs of the columns of the rotated loading matrix such that the sum of
+             loadings is non-negative for all columns (default: true)
+- `verbose`: Print logging statements (default: true)
 
 ## Return type
 The `rotate` function returns a [`FactorRotation`](@ref) object.
@@ -100,6 +102,7 @@ function rotate(
     verbose = VERBOSITY[],
     randomstarts = false,
     normalize = false,
+    reflect = true,
     kwargs...,
 )
     loglevel = verbose ? Logging.Info : Logging.Debug
@@ -170,7 +173,11 @@ function rotate(
         kaiser_denormalize!(rotation.L, weights)
     end
 
-    return FactorRotation(rotation.L, rotation.T, weights)
+    rot = FactorRotation(rotation.L, rotation.T, weights)
+
+    reflect && reflect!(rot)
+
+    return rot
 end
 
 function parse_randomstarts(x::Bool; default = 100)

--- a/test/reflect.jl
+++ b/test/reflect.jl
@@ -1,0 +1,24 @@
+@testset "reflect" begin
+    @test FactorRotations.reflect_cols(ones(8, 3)) == ones(1, 3)
+    @test FactorRotations.reflect_cols(hcat(ones(8), -ones(8))) == [1 -1]
+    @test FactorRotations.reflect_cols(hcat(-ones(8), zeros(8), ones(8))) == [-1 1 1]
+
+    @testset "FactorRotation" begin
+        Imat = diagm(ones(Float64, 3))
+        r = FactorRotation(hcat(ones(4), zeros(4), -ones(4)), Imat, ones(4))
+        expectation = FactorRotation(
+            hcat(ones(4), zeros(4), ones(4)),
+            diagm(Float64[1, 1, -1]),
+            ones(4),
+        )
+
+        @test reflect(r).T == expectation.T
+        @test reflect(r).L == expectation.L
+        @test reflect(r).phi == expectation.phi
+
+        reflect!(r)
+        @test r.T == expectation.T
+        @test r.L == expectation.L
+        @test r.phi == expectation.phi
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,4 +21,5 @@ init = Matrix{Float64}(I, 2, 2)
     include("normalize.jl")
     include("methods.jl")
     include("rotate.jl")
+    include("reflect.jl")
 end


### PR DESCRIPTION
This pull request implements `reflect` and `reflect!` functions, as well as the keyword argumement `reflect` to `rotate`. 

Reflect modifies the rotated loading matrix by swapping signs columnwise such that the sum of all factor loadings is non-negative.

This is a breaking change, since the default is `reflect = true` in `rotate`.

closes #50 
closes #52 

