### PR TITLE
Fix Varimax

### DIFF
--- a/src/methods/varimax.jl
+++ b/src/methods/varimax.jl
@@ -29,7 +29,9 @@ true
 struct Varimax <: RotationMethod{Orthogonal} end
 
 function criterion(::Varimax, Λ::AbstractMatrix)
-    Q = -norm(Λ .^ 2)^2 / 4
+    Λsq = Λ .^ 2
+    centercols!(Λsq)
+    Q = -norm(Λsq)^2 / 4
     return Q
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -4,14 +4,14 @@ function test_criterion_and_gradient(method, Λ)
     @test Q isa Real
     @test ∇Q isa AbstractMatrix{<:Real}
     @test size(∇Q) == size(Λ)
+
     # test the criterion() method if available
-    try
+    if applicable(criterion, method, Λ)
         Q2 = criterion(method, Λ)
         @test Q2 isa Real
         @test Q ≈ Q2
-    catch e
-        isa(e, MethodError) || rethrow(e)
     end
+
     return nothing
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -4,6 +4,14 @@ function test_criterion_and_gradient(method, Λ)
     @test Q isa Real
     @test ∇Q isa AbstractMatrix{<:Real}
     @test size(∇Q) == size(Λ)
+    # test the criterion() method if available
+    try
+        Q2 = criterion(method, Λ)
+        @test Q2 isa Real
+        @test Q ≈ Q2
+    catch e
+        isa(e, MethodError) || rethrow(e)
+    end
     return nothing
 end
 


### PR DESCRIPTION
As I noticed in #48, *criterion(::Varimax)* does not center the columns (but *criterion_and_gradient()* does), which means that it does not calculate the variances.
I've fixed that, and added the test that *criterion()* gives the same result as *criterion_and_gradient()*, when available.

But if in the long run you consider switching to a unified in-place *criterion_and_gradient!(grad::Union{AbstractVector, Nothing}, ...)*, which would skip gradient calculation if *grad === nothing*, this PR would be irrelevant.
Right now the profiling shows that for a 62x24 matrix rotation ~10% is spent in the array allocation (both gradient calculation and projection).