### PR TITLE
Enhance logging

### DIFF
--- a/src/rotate.jl
+++ b/src/rotate.jl
@@ -62,7 +62,10 @@ Perform a rotation of the factor loading matrix `Λ` using a rotation `method`.
               (default: 1000).
 - `maxiter2`: Controls the number of maximum iterations in the inner loop of the algorithm
               (default: 10).
-- `normalize`: Perform Kaiser normalization before rotation of the loading matrix (default: false).
+- `normalize`: Perform Kaiser normalization before rotation of the loading matrix
+               (default: false).
+- `qtol`: Sets the absolute tolerance for the comparison of minimum criterion values when
+          with random starts (default: 1e-6).
 - `randomstarts`: Determines if the algorithm should be started from random starting values.
                   If `randomstarts = false` (the default), the algorithm is calculated once
                   for the initial values provided by `init`.
@@ -105,6 +108,7 @@ function rotate(
     normalize = false,
     reflect = true,
     atol = 1e-6,
+    qtol = 1e-6,
     kwargs...,
 )
     loglevel = verbose ? Logging.Info : Logging.Debug
@@ -147,7 +151,7 @@ function rotate(
 
             Q_current = minimumQ(random_rotation)
 
-            if isapprox(Q_current, Q_min; atol)
+            if isapprox(Q_current, Q_min, atol = qtol)
                 n_at_Q_min += 1
             elseif Q_current < Q_min
                 @logmsg loglevel "Found new minimum at Q = $(Q_current)"
@@ -334,8 +338,8 @@ function _rotate(
         end
 
         (i == 1 || i == maxiter1 || mod(i, logperiod) == 0) &&
-        @logmsg loglevel "Current optimization state:" iteration = i criterion = Q alpha =
-            alpha
+            @logmsg loglevel "Current optimization state:" iteration = i criterion = Q alpha =
+                alpha
 
         iteration_state = IterationState(alpha, maxiter2, Q)
         push!(state.iterations, iteration_state)

--- a/src/rotate.jl
+++ b/src/rotate.jl
@@ -73,6 +73,7 @@ Perform a rotation of the factor loading matrix `Λ` using a rotation `method`.
 - `reflect`: Switch signs of the columns of the rotated loading matrix such that the sum of
              loadings is non-negative for all columns (default: true)
 - `verbose`: Print logging statements (default: true)
+- `logperiod`: How frequently to report the optimization state (default: 100).
 
 ## Return type
 The `rotate` function returns a [`FactorRotation`](@ref) object.
@@ -288,6 +289,7 @@ function _rotate(
     maxiter1 = 1000,
     maxiter2 = 10,
     init::Union{Nothing,AbstractMatrix} = nothing,
+    logperiod::Integer = 100,
     loglevel,
 ) where {RT,TV<:Real}
     @logmsg loglevel "Initializing rotation using algorithm $(typeof(method))."
@@ -329,6 +331,7 @@ function _rotate(
             end
         end
 
+        (i == 1 || i == maxiter1 || mod(i, logperiod) == 0) &&
         @logmsg loglevel "Current optimization state:" iteration = i criterion = Q alpha =
             alpha
 

--- a/src/rotate.jl
+++ b/src/rotate.jl
@@ -136,6 +136,7 @@ function rotate(
                 _rotate(L, method; loglevel, kwargs..., init)
             catch err
                 if err isa ConvergenceError
+                    @logmsg loglevel err.msg
                     n_diverged += 1
                     continue
                 else
@@ -340,7 +341,7 @@ function _rotate(
     end
 
     if !isconverged(s, atol)
-        msg = "Algorithm did not converge after $(maxiter1) iterations"
+        msg = "Algorithm did not converge after $(maxiter1) iterations (|∇G|=$(s) > $(atol))"
         throw(ConvergenceError(msg))
     end
 

--- a/src/rotate.jl
+++ b/src/rotate.jl
@@ -104,6 +104,7 @@ function rotate(
     randomstarts = false,
     normalize = false,
     reflect = true,
+    atol = 1e-6,
     kwargs...,
 )
     loglevel = verbose ? Logging.Info : Logging.Debug
@@ -119,7 +120,7 @@ function rotate(
 
     # rotation
     if starts == 0
-        rotation = _rotate(L, method; loglevel, kwargs...)
+        rotation = _rotate(L, method; atol, loglevel, kwargs...)
     else
         if :init in keys(kwargs)
             @warn "Requested random starts but keyword argument `init` was provided. Ignoring initial starting values in `init`."
@@ -133,7 +134,7 @@ function rotate(
         for _ in 1:starts
             init = random_orthogonal_matrix(size(L, 2))
             random_rotation = try
-                _rotate(L, method; loglevel, kwargs..., init)
+                _rotate(L, method; atol, loglevel, kwargs..., init)
             catch err
                 if err isa ConvergenceError
                     @logmsg loglevel err.msg
@@ -146,7 +147,7 @@ function rotate(
 
             Q_current = minimumQ(random_rotation)
 
-            if Q_current ≈ Q_min
+            if isapprox(Q_current, Q_min; atol)
                 n_at_Q_min += 1
             elseif Q_current < Q_min
                 @logmsg loglevel "Found new minimum at Q = $(Q_current)"

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -278,7 +278,7 @@ end
 
         # test that rotation result is identical published results by
         # Bernaards & Jennrich (2005) within the reported accuracy of 7 digits
-        Ar = rotate(A, Quartimax(); init, atol = 1e-5)
+        Ar = rotate(A, Quartimax(); init, g_atol = 1e-5)
         Ar = round.(loadings(Ar), digits = 7)
 
         pub = [


### PR DESCRIPTION
Some minor quality of life logging tweaks:
  * add `logperiod` option to specify how frequently to log the optimization state
  * when the convergence fails, the error/log message would show the final gradient norm (I'm not sure how to call that matrix though), so the user can estimate how far it is from the `atol`
  * `atol` is also used to compare the best and current solution.
     So when `rotate()` reports how many random starts reached the same criterion, it matches the specified tolerance (alternatively, `rotate()` may support both `g_atol` and `f_atol`)