### PR TITLE
Inline calculations

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -59,7 +59,6 @@ Oblique
 Orthogonal
 RotationMethod
 criterion
-FactorRotations.criterion_only
 criterion_and_gradient!
 ConvergenceError
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -59,6 +59,7 @@ Oblique
 Orthogonal
 RotationMethod
 criterion
-criterion_and_gradient
+FactorRotations.criterion_only
+criterion_and_gradient!
 ConvergenceError
 ```

--- a/src/FactorRotations.jl
+++ b/src/FactorRotations.jl
@@ -14,7 +14,7 @@ export setverbosity!
 
 export FactorRotation, loadings, rotation, factor_correlation
 export rotate, rotate!
-export criterion, criterion_and_gradient
+export criterion, criterion_and_gradient!
 export ConvergenceError
 
 export reflect, reflect!

--- a/src/methods/biquartimin.jl
+++ b/src/methods/biquartimin.jl
@@ -14,7 +14,7 @@ struct Biquartimin{RT} <: RotationMethod{RT}
     end
 end
 
-function criterion_and_gradient!(∇Q, ::Biquartimin, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, ::Biquartimin, Λ::AbstractMatrix)
     p, k = size(Λ)
     n = k - 1
 

--- a/src/methods/biquartimin.jl
+++ b/src/methods/biquartimin.jl
@@ -14,7 +14,7 @@ struct Biquartimin{RT} <: RotationMethod{RT}
     end
 end
 
-function criterion_and_gradient(::Biquartimin, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, ::Biquartimin, Λ::AbstractMatrix)
     p, k = size(Λ)
     n = k - 1
 
@@ -24,7 +24,11 @@ function criterion_and_gradient(::Biquartimin, Λ::AbstractMatrix)
 
     Q = sum(Λ₂sq .* (Λ₂sq * N))
 
-    ∇Q = zeros(size(Λ))
-    ∇Q[:, 2:end] .= 4 * Λ₂ .* (Λ₂sq * N)
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q[:, 1] .= zero(eltype(∇Q))
+        ∇Q₂ = @view ∇Q[:, 2:end]
+        ∇Q₂ .= Λ₂ .* (Λ₂sq * N)
+        lmul!(4, ∇Q)
+    end
+    return Q
 end

--- a/src/methods/component_loss.jl
+++ b/src/methods/component_loss.jl
@@ -7,7 +7,7 @@ Implementing a custom component loss `T` requires that `T <: AbstractComponentLo
 """
 abstract type AbstractComponentLoss{RT} <: RotationMethod{RT} end
 
-criterion(method::AbstractComponentLoss, Λ::AbstractMatrix) = -sum(method.loss, Λ)
+criterion(method::AbstractComponentLoss, Λ::AbstractMatrix{<:Real}) = -sum(method.loss, Λ)
 
 """
     ComponentLoss(loss::Function; orthogonal = false)

--- a/src/methods/component_loss.jl
+++ b/src/methods/component_loss.jl
@@ -7,7 +7,7 @@ Implementing a custom component loss `T` requires that `T <: AbstractComponentLo
 """
 abstract type AbstractComponentLoss{RT} <: RotationMethod{RT} end
 
-criterion(method::AbstractComponentLoss, Λ::AbstractMatrix{<:Real}) = -sum(method.loss, Λ)
+criterion_only(method::AbstractComponentLoss, Λ::AbstractMatrix{<:Real}) = -sum(method.loss, Λ)
 
 """
     ComponentLoss(loss::Function; orthogonal = false)

--- a/src/methods/component_loss.jl
+++ b/src/methods/component_loss.jl
@@ -7,7 +7,7 @@ Implementing a custom component loss `T` requires that `T <: AbstractComponentLo
 """
 abstract type AbstractComponentLoss{RT} <: RotationMethod{RT} end
 
-criterion_only(method::AbstractComponentLoss, Λ::AbstractMatrix{<:Real}) = -sum(method.loss, Λ)
+criterion_and_gradient!(::Nothing, method::AbstractComponentLoss, Λ::AbstractMatrix{<:Real}) = -sum(method.loss, Λ)
 
 """
     ComponentLoss(loss::Function; orthogonal = false)

--- a/src/methods/crawford_ferguson.jl
+++ b/src/methods/crawford_ferguson.jl
@@ -37,19 +37,21 @@ struct CrawfordFerguson{T,V} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient(method::CrawfordFerguson, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q, method::CrawfordFerguson, Λ::AbstractMatrix{T}) where {T}
     @unpack κ = method
     p, k = size(Λ)
 
-    N = ones(T, k, k) |> zerodiag!
-    M = ones(T, p, p) |> zerodiag!
+    N = Ones(k, k) - I(k)
+    M = Ones(p, p) - I(p)
 
     Λsq = Λ .^ 2
 
     ΛsqN = Λsq * N
     MΛsq = M * Λsq
 
-    Q = (1 - κ) * tr(Λsq' * ΛsqN) / 4 + κ * tr(Λsq' * MΛsq) / 4
-    ∇Q = (1 - κ) * Λ .* ΛsqN + κ * Λ .* MΛsq
-    return Q, ∇Q
+    Q = ((1 - κ)/4) * tr(Λsq' * ΛsqN) + (κ/4) * tr(Λsq' * MΛsq)
+    if !isnothing(∇Q)
+        @. ∇Q = (1 - κ) * Λ * ΛsqN + κ * Λ * MΛsq
+    end
+    return Q
 end

--- a/src/methods/crawford_ferguson.jl
+++ b/src/methods/crawford_ferguson.jl
@@ -37,7 +37,7 @@ struct CrawfordFerguson{T,V} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient!(∇Q, method::CrawfordFerguson, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q::OptionalGradient, method::CrawfordFerguson, Λ::AbstractMatrix{T}) where {T}
     @unpack κ = method
     p, k = size(Λ)
 

--- a/src/methods/geomin.jl
+++ b/src/methods/geomin.jl
@@ -14,7 +14,7 @@ struct Geomin{T} <: RotationMethod{Oblique}
     end
 end
 
-function criterion_and_gradient!(∇Q, method::Geomin, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q::OptionalGradient, method::Geomin, Λ::AbstractMatrix{T}) where {T}
     @unpack ε = method
     Λsq = Λ .^ 2 .+ ε
     p, k = size(Λ)

--- a/src/methods/geomin.jl
+++ b/src/methods/geomin.jl
@@ -14,26 +14,19 @@ struct Geomin{T} <: RotationMethod{Oblique}
     end
 end
 
-function criterion(method::Geomin, Λ::AbstractMatrix{T}) where {T}
-    @unpack ε = method
-    Λsq = Λ .^ 2 .+ ε
-    p, k = size(Λ)
-    u = Ones(T, p)
-    v = Ones(T, k)
-    Q = u' * exp.((log.(Λsq) ./ k * v))
-    return Q
-end
-
-function criterion_and_gradient(method::Geomin, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q, method::Geomin, Λ::AbstractMatrix{T}) where {T}
     @unpack ε = method
     Λsq = Λ .^ 2 .+ ε
     p, k = size(Λ)
     u = Ones(T, p)
     v = Ones(T, k)
 
-    part = exp.((log.(Λsq) ./ k * v))
+    part = exp.((log.(Λsq) * v) ./ k)
     Q = u' * part
-    ∇Q = (2 ./ k) .* (1 ./ Λsq) .* Λ .* (part * v')
+    if !isnothing(∇Q)
+        mul!(∇Q, part, v')
+        ∇Q .*= (2 / k) .* inv.(Λsq) .* Λ
+    end
 
-    return Q, ∇Q
+    return Q
 end

--- a/src/methods/infomax.jl
+++ b/src/methods/infomax.jl
@@ -14,33 +14,34 @@ struct Infomax{T} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient(::Infomax, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q, ::Infomax, Λ::AbstractMatrix{T}) where {T}
     p, k = size(Λ)
     Λsq = Λ .^ 2
 
     total = sum(Λsq)
+    Λsq ./= total
     rowsums = sum(Λsq, dims = 2)
     colsums = sum(Λsq, dims = 1)
 
-    Q =
-        -log(k) + sum(mxlogx, Λsq / total) - sum(mxlogx, rowsums / total) -
-        sum(mxlogx, colsums / total)
+    Q = -log(k) + sum(mxlogx, Λsq) - sum(mxlogx, rowsums) -
+        sum(mxlogx, colsums)
+    isnothing(∇Q) && return Q
 
     u = Ones(T, p)
     v = Ones(T, k)
 
-    H = @. -(log(Λsq / total) + 1)
-    α = u' * (Λsq .* H) * v / total^2
+    H = @. -(log(Λsq) + 1)
+    α = u' * (Λsq .* H) * v / total
     G₀ = H / total - α * u * v'
 
-    h₁ = -(log.(Λsq * v / total) .+ 1)
-    α₁ = v' * Λsq' * h₁ / total^2
+    h₁ = -(log.(Λsq * v) .+ 1)
+    α₁ = v' * Λsq' * h₁ / total
     G₁ = h₁ * v' / total - α₁ * u * v'
 
-    h₂ = -(log.(u' * Λsq / total) .+ 1)
-    α₂ = h₂ * Λsq' * u / total^2
+    h₂ = -(log.(u' * Λsq) .+ 1)
+    α₂ = h₂ * Λsq' * u / total
     G₂ = u * h₂ / total - α₂ .* u * v'
 
-    ∇Q = @. 2Λ * (G₀ - G₁ - G₂)
-    return Q, ∇Q
+    @. ∇Q = 2Λ * (G₀ - G₁ - G₂)
+    return Q
 end

--- a/src/methods/infomax.jl
+++ b/src/methods/infomax.jl
@@ -14,7 +14,7 @@ struct Infomax{T} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient!(∇Q, ::Infomax, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q::OptionalGradient, ::Infomax, Λ::AbstractMatrix{T}) where {T}
     p, k = size(Λ)
     Λsq = Λ .^ 2
 

--- a/src/methods/methods.jl
+++ b/src/methods/methods.jl
@@ -16,21 +16,27 @@ abstract type RotationMethod{T<:RotationType} end
 
 Calculate the criterion of a given `method` with respect to the factor loading matrix `Λ`.
 """
-function criterion end
+criterion(method::RotationMethod, Λ::AbstractMatrix{<:Real}) = criterion_and_gradient!(nothing, method, Λ)
 
 """
-    criterion_and_gradient(method::RotationMethod, Λ::AbstractMatrix{<:Real})
+    criterion_and_gradient!(∇Q::Union{AbstractMatrix{<:Real}, Nothing},
+                            method::RotationMethod, Λ::AbstractMatrix{<:Real})
 
-Calculate the criterion and gradient of a given `method` with respect to the factor loading
-matrix `Λ`.
+Calculate the quality criterion *Q* and the gradient of a given `method`
+with respect to the factor loading matrix `Λ`.
+The gradient is output into `∇Q`.
+The *∇Q* calculation is skipped if `∇Q = nothing`.
 
-Returns a Tuple with the criterion value as the first element and gradient as the second
-element.
+Returns the *Q* criterion value.
 """
-function criterion_and_gradient(method::RotationMethod, Λ::AbstractMatrix)
-    Q = criterion(method, Λ)
-    ∇Q = gradient(Reverse, Base.Fix1(criterion, method), Λ)
-    return Q, ∇Q
+criterion_and_gradient!
+
+# fallback method that uses AutoDiff
+function criterion_and_gradient!(∇Q, method::RotationMethod, Λ::AbstractMatrix)
+    if !isnothing(∇Q)
+        gradient!(Reverse, ∇Q, Base.Fix1(criterion, method), Λ)
+    end
+    return criterion(method, Λ)
 end
 
 """

--- a/src/methods/methods.jl
+++ b/src/methods/methods.jl
@@ -31,12 +31,18 @@ Returns the *Q* criterion value.
 """
 criterion_and_gradient!
 
+
+# RotationMethod that relies on AutoDiff for gradient evaluation
+# should implement criterion_only() method instead of criterion_and_gradient!()
+criterion_only(method::RotationMethod, Λ::AbstractMatrix) =
+    error("$(typeof(method)) does not implement neither criterion_and_gradient!() nor criterion_only() methods.")
+
 # fallback method that uses AutoDiff
 function criterion_and_gradient!(∇Q, method::RotationMethod, Λ::AbstractMatrix)
     if !isnothing(∇Q)
-        gradient!(Reverse, ∇Q, Base.Fix1(criterion, method), Λ)
+        gradient!(Reverse, ∇Q, Base.Fix1(criterion_only, method), Λ)
     end
-    return criterion(method, Λ)
+    return criterion_only(method, Λ)
 end
 
 """

--- a/src/methods/minimum_entropy.jl
+++ b/src/methods/minimum_entropy.jl
@@ -5,10 +5,12 @@ The Minimum Entropy rotation method.
 """
 struct MinimumEntropy <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient(::MinimumEntropy, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, ::MinimumEntropy, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     logΛsq = log.(Λsq)
     Q = -tr(Λsq' * logΛsq) / 2
-    ∇Q = -Λ .* logΛsq - Λ
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        @. ∇Q = (-1 - logΛsq) * Λ
+    end
+    return Q
 end

--- a/src/methods/minimum_entropy.jl
+++ b/src/methods/minimum_entropy.jl
@@ -5,7 +5,7 @@ The Minimum Entropy rotation method.
 """
 struct MinimumEntropy <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient!(∇Q, ::MinimumEntropy, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, ::MinimumEntropy, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     logΛsq = log.(Λsq)
     Q = -tr(Λsq' * logΛsq) / 2

--- a/src/methods/minimum_entropy_ratio.jl
+++ b/src/methods/minimum_entropy_ratio.jl
@@ -5,7 +5,7 @@ The Minimum Entropy Ratio rotation method.
 """
 struct MinimumEntropyRatio <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient!(∇Q, ::MinimumEntropyRatio, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q::OptionalGradient, ::MinimumEntropyRatio, Λ::AbstractMatrix{T}) where {T}
     p, k = size(Λ)
     Λsq = Λ .^ 2
 

--- a/src/methods/minimum_entropy_ratio.jl
+++ b/src/methods/minimum_entropy_ratio.jl
@@ -5,7 +5,7 @@ The Minimum Entropy Ratio rotation method.
 """
 struct MinimumEntropyRatio <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient(::MinimumEntropyRatio, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q, ::MinimumEntropyRatio, Λ::AbstractMatrix{T}) where {T}
     p, k = size(Λ)
     Λsq = Λ .^ 2
 
@@ -17,6 +17,7 @@ function criterion_and_gradient(::MinimumEntropyRatio, Λ::AbstractMatrix{T}) wh
     Q₁ = sum(mxlogx, Λsq / colsums)
     Q₂ = sum(mxlogx, p₂)
     Q = log(Q₁) - log(Q₂)
+    isnothing(∇Q) && return Q
 
     u = Ones(T, p)
     v = Ones(T, k)
@@ -30,7 +31,7 @@ function criterion_and_gradient(::MinimumEntropyRatio, Λ::AbstractMatrix{T}) wh
     h = @. -(log(p₂) + 1)
     α = h * p₂'
     G₂ = u * h / total - α .* u * v'
-    ∇Q = @. 2Λ * (G₁ / Q₁ - G₂ / Q₂)
+    @. ∇Q = 2Λ * (G₁ / Q₁ - G₂ / Q₂)
 
-    return Q, ∇Q
+    return Q
 end

--- a/src/methods/oblimax.jl
+++ b/src/methods/oblimax.jl
@@ -28,12 +28,15 @@ struct Oblimax{T} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient(::Oblimax, Λ::AbstractMatrix)
-    sqnorm_Λsq = norm(Λ .^ 2) .^ 2
-    norm_Λ = norm(Λ)
+function criterion_and_gradient!(∇Q, ::Oblimax, Λ::AbstractMatrix)
+    sqnorm_Λsq = sum(x -> x^4, Λ)
+    sqnorm_Λ = norm(Λ)^2
 
-    K = sqnorm_Λsq / norm_Λ^4
+    K = sqnorm_Λsq / sqnorm_Λ^2
     Q = -log(K)
-    ∇Q = -4Λ .^ 3 / sqnorm_Λsq + 4Λ / norm_Λ^2
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q .= Λ .^ 3
+        axpby!(4/sqnorm_Λ, Λ, -4/sqnorm_Λsq, ∇Q)
+    end
+    return Q
 end

--- a/src/methods/oblimax.jl
+++ b/src/methods/oblimax.jl
@@ -28,7 +28,7 @@ struct Oblimax{T} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient!(∇Q, ::Oblimax, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, ::Oblimax, Λ::AbstractMatrix)
     sqnorm_Λsq = sum(x -> x^4, Λ)
     sqnorm_Λ = norm(Λ)^2
 

--- a/src/methods/oblimin.jl
+++ b/src/methods/oblimin.jl
@@ -40,7 +40,7 @@ struct Oblimin{T,V} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient(method::Oblimin, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q, method::Oblimin, Λ::AbstractMatrix{T}) where {T}
     @unpack γ = method
     p, k = size(Λ)
     C = Fill(1 / p, p, p)
@@ -52,6 +52,8 @@ function criterion_and_gradient(method::Oblimin, Λ::AbstractMatrix{T}) where {T
     part = (I - γ * C) * Λsq * N
 
     Q = tr(Λsq' * part) / 4
-    ∇Q = Λ .* part
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q .= Λ .* part
+    end
+    return Q
 end

--- a/src/methods/oblimin.jl
+++ b/src/methods/oblimin.jl
@@ -40,7 +40,7 @@ struct Oblimin{T,V} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient!(∇Q, method::Oblimin, Λ::AbstractMatrix{T}) where {T}
+function criterion_and_gradient!(∇Q::OptionalGradient, method::Oblimin, Λ::AbstractMatrix{T}) where {T}
     @unpack γ = method
     p, k = size(Λ)
     C = Fill(1 / p, p, p)

--- a/src/methods/pattern_simplicity.jl
+++ b/src/methods/pattern_simplicity.jl
@@ -14,17 +14,13 @@ struct PatternSimplicity{RT} <: RotationMethod{RT}
     end
 end
 
-function criterion(method::PatternSimplicity, Λ::AbstractMatrix)
-    Λsq = Λ .^ 2
-    m = Λsq' * Λsq
-    return logdet((diagm(diag(m)))) - logdet(m)
-end
-
-function criterion_and_gradient(method::PatternSimplicity, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, method::PatternSimplicity, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     m = Λsq' * Λsq
     diag_m = diagm(diag(m))
-    Q = logdet(diag_m) - logdet(m)
-    ∇Q = -4 * Λ .* (Λsq * (inv(m) - inv(diag_m)))
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q .= Λ .* (Λsq * (inv(m) - inv(diag_m)))
+        lmul!(-4, ∇Q)
+    end
+    return logdet(diag_m) - logdet(m)
 end

--- a/src/methods/pattern_simplicity.jl
+++ b/src/methods/pattern_simplicity.jl
@@ -14,7 +14,7 @@ struct PatternSimplicity{RT} <: RotationMethod{RT}
     end
 end
 
-function criterion_and_gradient!(∇Q, method::PatternSimplicity, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, method::PatternSimplicity, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     m = Λsq' * Λsq
     diag_m = diagm(diag(m))

--- a/src/methods/quartimax.jl
+++ b/src/methods/quartimax.jl
@@ -28,10 +28,9 @@ true
 """
 struct Quartimax <: RotationMethod{Orthogonal} end
 
-criterion(method::Quartimax, Λ::AbstractMatrix{<:Real}) = -sum(x -> x^4, Λ) / 4
-
-function criterion_and_gradient(method::Quartimax, Λ::AbstractMatrix)
-    Q = criterion(method, Λ)
-    ∇Q = @. -Λ^3
-    return Q, ∇Q
+function criterion_and_gradient!(∇Q, method::Quartimax, Λ::AbstractMatrix)
+    if !isnothing(∇Q)
+        @. ∇Q = -Λ^3
+    end
+    return -sum(x -> x^4, Λ) / 4
 end

--- a/src/methods/quartimax.jl
+++ b/src/methods/quartimax.jl
@@ -28,7 +28,7 @@ true
 """
 struct Quartimax <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient!(∇Q, method::Quartimax, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, method::Quartimax, Λ::AbstractMatrix)
     if !isnothing(∇Q)
         @. ∇Q = -Λ^3
     end

--- a/src/methods/simplimax.jl
+++ b/src/methods/simplimax.jl
@@ -11,19 +11,14 @@ struct Simplimax <: RotationMethod{Oblique}
     end
 end
 
-function criterion(method::Simplimax, Λ::AbstractMatrix)
-    Λsq = Λ .^ 2
-    λm = nthsmallest(Λsq, method.m)
-    Q = tr(Λsq' * (Λsq .<= λm)) / 2
-    return Q
-end
-
-function criterion_and_gradient(method::Simplimax, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, method::Simplimax, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     λm = nthsmallest(Λsq, method.m)
     Λind = Λsq .<= λm
 
     Q = tr(Λsq' * Λind) / 2
-    ∇Q = Λ .* Λind
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q .= Λ .* Λind
+    end
+    return Q
 end

--- a/src/methods/simplimax.jl
+++ b/src/methods/simplimax.jl
@@ -11,7 +11,7 @@ struct Simplimax <: RotationMethod{Oblique}
     end
 end
 
-function criterion_and_gradient!(∇Q, method::Simplimax, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, method::Simplimax, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     λm = nthsmallest(Λsq, method.m)
     Λind = Λsq .<= λm

--- a/src/methods/tandem_criteria.jl
+++ b/src/methods/tandem_criteria.jl
@@ -5,18 +5,15 @@ The first criterion of the tandem criteria factor rotation method.
 """
 struct TandemCriterionI <: RotationMethod{Orthogonal} end
 
-function criterion(method::TandemCriterionI, Λ::AbstractMatrix)
-    Λsq = Λ .^ 2
-    return -tr(Λsq' * ((Λ * Λ') .^ 2 * Λsq))
-end
-
-function criterion_and_gradient(method::TandemCriterionI, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, method::TandemCriterionI, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     ΛxΛ = Λ * Λ'
     part = ΛxΛ .^ 2 * Λsq
-    Q = -tr(Λsq' * part)
-    ∇Q = -4 * Λ .* part - 4 * (ΛxΛ .* (Λsq * Λsq')) * Λ
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q .= Λ .* part .+ (ΛxΛ .* (Λsq * Λsq')) * Λ
+        lmul!(-4, ∇Q)
+    end
+    return -tr(Λsq' * part)
 end
 
 """
@@ -26,28 +23,18 @@ The second criterion of the tandem criteria factor rotation method.
 """
 struct TandemCriterionII <: RotationMethod{Orthogonal} end
 
-function criterion(method::TandemCriterionII, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, method::TandemCriterionII, Λ::AbstractMatrix)
     p, k = size(Λ)
     u = Ones(p)
     Λsq = Λ .^ 2
     ΛxΛ = Λ * Λ'
     ΛxΛsq = ΛxΛ .^ 2
     part = (u * u' - ΛxΛsq) * Λsq
-    Q = tr(Λsq' * part)
-    return Q
-end
-
-function criterion_and_gradient(method::TandemCriterionII, Λ::AbstractMatrix)
-    p, k = size(Λ)
-    u = Ones(p)
-    Λsq = Λ .^ 2
-    ΛxΛ = Λ * Λ'
-    ΛxΛsq = ΛxΛ .^ 2
-    part = (u * u' - ΛxΛsq) * Λsq
-    Q = tr(Λsq' * part)
-
-    ∇Q = 4 * Λ .* part - 4 * (ΛxΛ .* (Λsq * Λsq')) * Λ
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        ∇Q .= Λ .* part
+        mul!(∇Q, ΛxΛ .* (Λsq * Λsq'), Λ, -4, 4)
+    end
+    return tr(Λsq' * part)
 end
 
 """

--- a/src/methods/tandem_criteria.jl
+++ b/src/methods/tandem_criteria.jl
@@ -5,7 +5,7 @@ The first criterion of the tandem criteria factor rotation method.
 """
 struct TandemCriterionI <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient!(∇Q, method::TandemCriterionI, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, method::TandemCriterionI, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     ΛxΛ = Λ * Λ'
     part = ΛxΛ .^ 2 * Λsq
@@ -23,7 +23,7 @@ The second criterion of the tandem criteria factor rotation method.
 """
 struct TandemCriterionII <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient!(∇Q, method::TandemCriterionII, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, method::TandemCriterionII, Λ::AbstractMatrix)
     p, k = size(Λ)
     u = Ones(p)
     Λsq = Λ .^ 2

--- a/src/methods/target_rotation.jl
+++ b/src/methods/target_rotation.jl
@@ -66,11 +66,12 @@ struct TargetRotation{T,V<:AbstractMatrix} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient(method::TargetRotation, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, method::TargetRotation, Λ::AbstractMatrix)
     @unpack H, W = method
     size(H) == size(Λ) ||
         throw(ArgumentError("target matrix and loading matrix must be of equal size"))
-    ∇Q = @. W * (Λ - H)
-    Q = norm(∇Q)^2 / 2
-    return Q, ∇Q
+    dQ = isnothing(∇Q) ? similar(Λ) : ∇Q
+    @. dQ = W * (Λ - H)
+    Q = norm(dQ)^2 / 2
+    return Q
 end

--- a/src/methods/target_rotation.jl
+++ b/src/methods/target_rotation.jl
@@ -66,7 +66,7 @@ struct TargetRotation{T,V<:AbstractMatrix} <: RotationMethod{T}
     end
 end
 
-function criterion_and_gradient!(∇Q, method::TargetRotation, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, method::TargetRotation, Λ::AbstractMatrix)
     @unpack H, W = method
     size(H) == size(Λ) ||
         throw(ArgumentError("target matrix and loading matrix must be of equal size"))

--- a/src/methods/varimax.jl
+++ b/src/methods/varimax.jl
@@ -28,17 +28,11 @@ true
 """
 struct Varimax <: RotationMethod{Orthogonal} end
 
-function criterion(::Varimax, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q, ::Varimax, Λ::AbstractMatrix)
     Λsq = Λ .^ 2
     centercols!(Λsq)
-    Q = -norm(Λsq)^2 / 4
-    return Q
-end
-
-function criterion_and_gradient(::Varimax, Λ::AbstractMatrix)
-    Λsq = Λ .^ 2
-    centercols!(Λsq)
-    Q = -norm(Λsq)^2 / 4
-    ∇Q = @. -Λ * Λsq
-    return Q, ∇Q
+    if !isnothing(∇Q)
+        @. ∇Q = -Λ * Λsq
+    end
+    return -norm(Λsq)^2 / 4
 end

--- a/src/methods/varimax.jl
+++ b/src/methods/varimax.jl
@@ -29,10 +29,12 @@ true
 struct Varimax <: RotationMethod{Orthogonal} end
 
 function criterion_and_gradient!(∇Q, ::Varimax, Λ::AbstractMatrix)
-    Λsq = Λ .^ 2
+    Λsq = isnothing(∇Q) ? similar(Λ) : ∇Q
+    Λsq .= Λ .^ 2
     centercols!(Λsq)
+    Q = -norm(Λsq)^2 / 4
     if !isnothing(∇Q)
-        @. ∇Q = -Λ * Λsq
+        @. ∇Q *= -Λ # ∇Q is already centered Λsq
     end
-    return -norm(Λsq)^2 / 4
+    return Q
 end

--- a/src/methods/varimax.jl
+++ b/src/methods/varimax.jl
@@ -28,7 +28,7 @@ true
 """
 struct Varimax <: RotationMethod{Orthogonal} end
 
-function criterion_and_gradient!(∇Q, ::Varimax, Λ::AbstractMatrix)
+function criterion_and_gradient!(∇Q::OptionalGradient, ::Varimax, Λ::AbstractMatrix)
     Λsq = isnothing(∇Q) ? similar(Λ) : ∇Q
     Λsq .= Λ .^ 2
     centercols!(Λsq)

--- a/src/rotate.jl
+++ b/src/rotate.jl
@@ -305,7 +305,8 @@ function _rotate(
 ) where {RT,TV<:Real}
     @logmsg loglevel "Initializing rotation using algorithm $(typeof(method))."
     state = initialize(RT, init, A; loglevel)
-    Q, ∇Q = criterion_and_gradient(method, state.L)
+    ∇Q = similar(state.L)
+    Q = criterion_and_gradient!(∇Q, method, state.L)
 
     @logmsg loglevel "Initial criterion value = $(Q)"
 
@@ -334,7 +335,7 @@ function _rotate(
             project_X!(Tt, state, X)
             update_state!(state, Tt)
 
-            Q, ∇Q = criterion_and_gradient(method, state.L)
+            Q = criterion_and_gradient!(∇Q, method, state.L)
 
             if (Q < ft - 0.5 * s^2 * α)
                 # update state.T (and reuse the old one for the next iteration)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -108,7 +108,7 @@ end
         @test_throws ArgumentError Concave(0)
         @test_throws ArgumentError Concave(-2)
 
-        method = Absolmin(0)
+        method = Absolmin(1e-5)
         @test isoblique(method)
         test_criterion_and_gradient(method, A)
         @test_throws ArgumentError Absolmin(-1.0)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -284,23 +284,36 @@ end
         # Quartimax is a special case of Oblimin
         test_equivalence(A, Quartimax(), Oblimin(gamma = 0, orthogonal = true); init)
 
-        # test that rotation result is identical published results by
-        # Bernaards & Jennrich (2005) within the reported accuracy of 7 digits
-        Ar = rotate(A, Quartimax(); init, g_atol = 1e-5)
-        Ar = round.(loadings(Ar), digits = 7)
+        # test that rotation result is identical to GPArotation
+        Ar = rotate(A, Quartimax(); init, g_atol = 1e-7)
 
-        pub = [
-            0.8987554 0.1948197
-            0.9339440 0.1297446
-            0.9021319 0.1038604
-            0.8765090 0.1712805
-            0.3155758 0.8764747
-            0.2511265 0.7734879
-            0.1980102 0.7146775
-            0.3078601 0.6593331
+        # loadings published in Bernaards & Jennrich (2005)
+        # within the reported accuracy of 7 digits
+        #pub = [
+        #    0.8987554 0.1948197
+        #    0.9339440 0.1297446
+        #    0.9021319 0.1038604
+        #    0.8765090 0.1712805
+        #    0.3155758 0.8764747
+        #    0.2511265 0.7734879
+        #    0.1980102 0.7146775
+        #    0.3078601 0.6593331
+        #]
+        # loadings obtained with GPArotation v2024.3
+        # quartimax(A, eps=1e-8, maxit=50000, randomStarts=10)
+        gpa = [
+            0.8987545678868889   0.19482357840480186
+            0.9339434064715286   0.1297486551312077
+            0.9021314838553653   0.10386426641014213
+            0.8765082522883497   0.1712842189765975
+            0.31557202157519415  0.87647606881132
+            0.2511231928032839   0.7734889411208703
+            0.19800711751346906  0.7146783762042948
+            0.3078572424280441   0.6593344510069232
         ]
 
-        @test Ar ≈ pub
+        @test FactorRotations.loadings(Ar) ≈ gpa atol=1e-6
+        @test criterion(Quartimax(), Ar.L) ≈ criterion(Quartimax(), gpa) atol = 1e-8
     end
 
     @testset "Simplimax" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -33,9 +33,9 @@ function test_equivalence(Λ, m1::RotationMethod, m2::RotationMethod; kwargs...)
     r1 = rotate(Λ, m1; kwargs...)
     r2 = rotate(Λ, m2; kwargs...)
 
-    @test isapprox(loadings(r1), loadings(r2), atol = 1e-5)
-    @test isapprox(rotation(r1), rotation(r2), atol = 1e-5)
-    @test isapprox(factor_correlation(r1), factor_correlation(r2), atol = 1e-5)
+    @test loadings(r1) ≈ loadings(r2) atol = 1e-5
+    @test rotation(r1) ≈ rotation(r2) atol = 1e-5
+    @test factor_correlation(r1) ≈ factor_correlation(r2) atol = 1e-5
 end
 
 @testset "factor rotation methods" begin

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -343,4 +343,12 @@ end
             init,
         )
     end
+
+    @testset "Missing criterion implementation" begin
+        struct NoCriterion <: RotationMethod{Orthogonal} end
+
+        @test_throws "NoCriterion does not implement" criterion(NoCriterion(), randn(6, 6))
+        # Enzyme.jl would refuse to autodiff because it detects that fallback criterion_only() throws an error
+        @test_throws "Function to differentiate" criterion_and_gradient!(randn(6, 5), NoCriterion(), randn(6, 5))
+    end
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -348,7 +348,7 @@ end
         struct NoCriterion <: RotationMethod{Orthogonal} end
 
         @test_throws "NoCriterion does not implement" criterion(NoCriterion(), randn(6, 6))
-        # Enzyme.jl would refuse to autodiff because it detects that fallback criterion_only() throws an error
+        # Enzyme.jl would refuse to autodiff because it detects that fallback criterion() throws an error
         @test_throws "Function to differentiate" criterion_and_gradient!(randn(6, 5), NoCriterion(), randn(6, 5))
     end
 end

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,5 +1,5 @@
 function test_criterion_and_gradient(method, Λ)
-    Q, ∇Q = criterion_and_gradient(method, Λ)
+    Q, ∇Q = @inferred(criterion_and_gradient(method, Λ))
 
     @test Q isa Real
     @test ∇Q isa AbstractMatrix{<:Real}
@@ -16,12 +16,12 @@ function test_criterion_and_gradient(method, Λ)
 end
 
 function test_rotate(method, Λ; init)
-    rot = rotate(Λ, method; init)
+    rot = @inferred(rotate(Λ, method; init))
     p, k = size(Λ)
 
-    @test size(loadings(rot)) == (p, k)
-    @test size(rotation(rot)) == (k, k)
-    @test size(factor_correlation(rot)) == (k, k)
+    @test size(@inferred(loadings(rot))) == (p, k)
+    @test size(@inferred(rotation(rot))) == (k, k)
+    @test size(@inferred(factor_correlation(rot))) == (k, k)
     @test loadings(rot) * rotation(rot)' ≈ Λ
 
     if isorthogonal(method)

--- a/test/rotate.jl
+++ b/test/rotate.jl
@@ -76,34 +76,44 @@
         @test_throws "Unsupported rotation type BadRotation" FactorRotations.RotationState(BadRotation, init, A)
     end
 
-    @testset "gradient_f" begin
+    @testset "gradient_f!" begin
         orthogonal_state = FactorRotations.RotationState(Orthogonal, init, A)
-        @test FactorRotations.gradient_f(orthogonal_state, zeros(size(A))) ==
+        g = fill!(similar(init), NaN)
+        @test g === FactorRotations.gradient_f!(g, orthogonal_state, zeros(size(A)))
+        @test FactorRotations.gradient_f!(g, orthogonal_state, zeros(size(A))) ==
               zeros(size(init))
 
         oblique_state = FactorRotations.RotationState(Oblique, init, A)
-        @test FactorRotations.gradient_f(oblique_state, zeros(size(A))) == zeros(size(init))
+        fill!(g, NaN)
+        @test g === FactorRotations.gradient_f!(g, oblique_state, zeros(size(A)))
+        @test FactorRotations.gradient_f!(g, oblique_state, zeros(size(A))) == zeros(size(init))
     end
 
     @testset "project_G!" begin
         Gp = zeros(Float64, size(init))
         G = rand(size(init)...)
         orthogonal_state = FactorRotations.RotationState(Orthogonal, init, A)
-        @test FactorRotations.project_G!(orthogonal_state, Gp, G) != zeros(size(init))
+        @test Gp === FactorRotations.project_G!(Gp, orthogonal_state, G)
+        @test FactorRotations.project_G!(Gp, orthogonal_state, G) != zeros(size(init))
         @test Gp != zeros(size(init))
 
         Gp = zeros(Float64, size(init))
         oblique_state = FactorRotations.RotationState(Oblique, init, A)
-        @test FactorRotations.project_G!(oblique_state, Gp, G) != zeros(size(init))
+        @test Gp === FactorRotations.project_G!(Gp, oblique_state, G)
+        @test FactorRotations.project_G!(Gp, oblique_state, G) != zeros(size(init))
         @test Gp != zeros(size(init))
     end
 
-    @testset "project_X" begin
+    @testset "project_X!" begin
         state = FactorRotations.RotationState(Orthogonal, init, A)
-        @test FactorRotations.project_X(state, I(2)) == I(2)
+        X = fill!(similar(init), NaN)
+        @test X === FactorRotations.project_X!(X, state, I(2))
+        @test FactorRotations.project_X!(X, state, I(2)) == I(2)
 
         state = FactorRotations.RotationState(Oblique, init, A)
-        @test FactorRotations.project_X(state, I(2)) == I(2)
+        fill!(X, NaN)
+        @test X === FactorRotations.project_X!(X, state, I(2))
+        @test FactorRotations.project_X!(X, state, I(2)) == I(2)
     end
 
     @testset "update_state!" begin

--- a/test/rotate.jl
+++ b/test/rotate.jl
@@ -27,8 +27,9 @@
     # convergence
     struct NonConverging <: RotationMethod{Orthogonal} end
 
-    function FactorRotations.criterion_and_gradient(::NonConverging, m::AbstractMatrix)
-        return (1.0, ones(size(m)))
+    function FactorRotations.criterion_and_gradient!(∇Q, ::NonConverging, m::AbstractMatrix)
+        isnothing(∇Q) || fill!(∇Q, one(eltype(∇Q)))
+        return 1.0
     end
 
     @test_throws ConvergenceError rotate(A, NonConverging())

--- a/test/rotate.jl
+++ b/test/rotate.jl
@@ -71,6 +71,9 @@
         @test oblique_state.L == A * inv(init)'
         @test oblique_state.iterations == FactorRotations.IterationState[]
         @test isnan(FactorRotations.minimumQ(oblique_state))
+
+        struct BadRotation <: FactorRotations.RotationType end
+        @test_throws "Unsupported rotation type BadRotation" FactorRotations.RotationState(BadRotation, init, A)
     end
 
     @testset "gradient_f" begin

--- a/test/rotate.jl
+++ b/test/rotate.jl
@@ -27,7 +27,7 @@
     # convergence
     struct NonConverging <: RotationMethod{Orthogonal} end
 
-    function FactorRotations.criterion_and_gradient!(∇Q, ::NonConverging, m::AbstractMatrix)
+    function FactorRotations.criterion_and_gradient!(∇Q::Union{Nothing, AbstractMatrix}, ::NonConverging, m::AbstractMatrix)
         isnothing(∇Q) || fill!(∇Q, one(eltype(∇Q)))
         return 1.0
     end

--- a/test/rotate.jl
+++ b/test/rotate.jl
@@ -3,11 +3,11 @@
     @test_throws ArgumentError rotate(A, Varimax(), init = rand(10, 10))
     @test_throws ArgumentError rotate(A, Varimax(), init = rand(8, 2))
 
-    rot_default_init = rotate(A, Varimax())
-    rot_identity_init = rotate(A, Varimax(); init)
-    @test loadings(rot_default_init) ≈ loadings(rot_identity_init)
-    @test rotation(rot_default_init) ≈ rotation(rot_identity_init)
-    @test factor_correlation(rot_default_init) ≈ factor_correlation(rot_identity_init)
+    rot_default_init = rotate(A, Varimax(), g_atol=1e-7)
+    rot_identity_init = rotate(A, Varimax(); g_atol=1e-7, init)
+    @test loadings(rot_default_init) ≈ loadings(rot_identity_init) atol=1e-7
+    @test rotation(rot_default_init) ≈ rotation(rot_identity_init) atol=1e-7
+    @test factor_correlation(rot_default_init) ≈ factor_correlation(rot_identity_init) atol=1e-7
 
     # in-place rotation
     B = copy(A)


### PR DESCRIPTION
Switches to in-line `criterion_and_gradient!()`, as well as in-line `gradient_f!()` and in-line `project_X!()`.

I have tried to reduce temporary array allocations by using methods like 5-arg `mul!()` or `axpy!()` and made some tweaks in specific rotation methods.
But more in-depth code analysis + profiling would be required to tune the performance (in future PRs).

Note that I have changed the reference Quartimax loadings (`pub` matrix) in the test: after the `crieterion_and_gradient!()` changes it started to fail, and increasing `atol` did not help.
So I have checked what is the output of the *GPArotation* package (from the same authors as the original 2005 publication), and it was also different from `pub`.
The Quartimax criterion based on the original `pub` loadings is smaller (by ~1e-6), but I suspect that is the result of the rounding error, and the corresponding rotation matrix would have been non-orthogonal.
The criterion difference between GPArotation and Quartimax was ~1e-16.

Fixes #57

