### PR TITLE
Move Enzyme.jl into extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Philipp Gewessler"]
 version = "0.4.0"
 
 [deps]
-Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,10 +13,12 @@ SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 MultivariateStats = "6f286f6a-111f-5878-ab1e-185364afe411"
 
 [extensions]
 MultivariateStatsExt = "MultivariateStats"
+EnzymeExt = "Enzyme"
 
 [compat]
 Enzyme = "0.11, 0.12"
@@ -33,4 +34,4 @@ julia = "1.9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "MultivariateStats"]
+test = ["Test", "MultivariateStats", "Enzyme"]

--- a/ext/EnzymeExt.jl
+++ b/ext/EnzymeExt.jl
@@ -1,0 +1,10 @@
+module EnzymeExt
+
+using FactorRotations
+using Enzyme: gradient!, Reverse
+
+# wrapper for Enzyme.gradient!
+FactorRotations.autodiff_gradient!(_::FactorRotations.AutodiffBackend{:Enzyme}, ∇Q::AbstractMatrix, method::RotationMethod, Λ::AbstractMatrix) =
+    gradient!(Reverse, ∇Q, Base.Fix1(criterion, method), Λ)
+
+end

--- a/src/FactorRotations.jl
+++ b/src/FactorRotations.jl
@@ -1,7 +1,6 @@
 module FactorRotations
 
 using Folds
-using Enzyme
 using FillArrays
 using LinearAlgebra
 using LogExpFunctions
@@ -59,6 +58,26 @@ If set to `true`, package functions will provide `@info` statements.
 function setverbosity!(verbose::Bool)
     @info "Logging is $(verbose ? "enabled" : "disabled") globally."
     VERBOSITY[] = verbose
+    return nothing
+end
+
+struct AutodiffBackend{B}
+    AutodiffBackend(backend::Symbol) = new{backend}()
+end
+
+const AUTODIFF_BACKEND = Ref{AutodiffBackend}(AutodiffBackend(:Enzyme))
+
+"""
+    set_autodiff_backend(backend::Symbol)
+
+Sets the *automatic differentiation* backend.
+
+Automatic differentiation is used by the fallback `criterion_and_gradient!()` implementation.
+Currently, only `:Enzyme` backend is supported.
+"""
+function set_autodiff_backend(backend::Symbol)
+    @info "Autodiff backend set to $(backend)."
+    AUTODIFF_BACKEND[] = AutodiffBackend(backend)
     return nothing
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -39,6 +39,16 @@ function test_equivalence(Λ, m1::RotationMethod, m2::RotationMethod; kwargs...)
     @test factor_correlation(r1) ≈ factor_correlation(r2) atol = 1e-5
 end
 
+@testset "factor rotation autodiff fallback" begin
+    method = ComponentLoss(abs2, orthogonal = true)
+    ∇Q = fill!(similar(A), NaN)
+
+    FactorRotations.set_autodiff_backend(:ABC)
+    @test_throws "ABC autodiff backend is not supported" criterion_and_gradient!(∇Q, method, A)
+    FactorRotations.set_autodiff_backend(:Enzyme)
+    #@test_throws "Enzyme.jl autodiff backend is not loaded" criterion_and_gradient!(∇Q, method, A)
+end
+
 @testset "factor rotation methods" begin
     @testset "utility functions" begin
         @test isorthogonal(Varimax()) != isoblique(Varimax())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using FactorRotations
 using LinearAlgebra
+using Enzyme
 using Statistics
 using Test
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -26,6 +26,14 @@
         setverbosity!(false)  # disable logging for following tests
     end
 
+    @testset "set_autodiff_backend" begin
+        @test FactorRotations.AUTODIFF_BACKEND[] == FactorRotations.AutodiffBackend(:Enzyme)
+        FactorRotations.set_autodiff_backend(:ABC)
+        @test FactorRotations.AUTODIFF_BACKEND[] == FactorRotations.AutodiffBackend(:ABC)
+        FactorRotations.set_autodiff_backend(:Enzyme)
+        @test FactorRotations.AUTODIFF_BACKEND[] == FactorRotations.AutodiffBackend(:Enzyme)
+    end
+
     @testset "centercols!" begin
         x = [1 2; 1 2]
         @test FactorRotations.centercols!(copy(x)) ≈ x .- mean(x, dims = 1)


### PR DESCRIPTION
*Enzyme.jl* is quite a heavy dependency (and comes with its own compatibility constraints), but it is not essential for factor rotations, as it is only used by *ComponentLoss* criteria family.

This PR does the following:
  * introduces internal *autodiff_gradient!()* method that is agnostic of a particular autodiff backend
  * adds *FactorRotations.set_autodiff_backend()* global config method (defaults to *Enzyme*)
  * makes *Enzyme.jl* a weak dependency, moves `autodiff_gradient!(::AutodiffBackend{:Enzyme}, ...)` implementation to *EnzymeExt*

So the only user-visible change after this PR would be to execute `using Enzyme` if autodiff is required.
It also opens the possibility to have alternative backends for autodiff in the future.