### PR TITLE
Document criterion formulas

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
         version:
           - '1.9'
           - '1.10'
+          - '1.11'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FactorRotations"
 uuid = "be5e9834-f3d9-4b7e-b5ea-d062861d4ac2"
 authors = ["Philipp Gewessler"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -6,31 +6,55 @@ CurrentModule = FactorRotations
 
 ## Rotation criteria
 
+Each of these rotation methods defines its specific quality criterion
+``Q(Λ)``, where ``Λ = L⋅R ∈ ℝ^{p \times k}`` is the rotated factor loading matrix,
+``L ∈ ℝ^{p \times k}`` is the original loading matrix, and ``R ∈ ℝ^{k \times k}``
+is the *rotation matrix*.
+The goal is to find the optimal rotation matrix ``R`` (either [*orthogonal*](@ref rotation_orthogonal)
+or [*oblique*](@ref rotation_oblique)) that will minimize ``Q(Λ)``.
+
+### Component loss-based
+
 ```@docs
-Absolmin
-Biquartimax
-Biquartimin
+AbstractComponentLoss
 ComponentLoss
+Absolmin
 Concave
-CrawfordFerguson
-Equamax
-Geomin
-Infomax
 KatzRohlf
 LinearRightConstant
+```
+
+### Based on column and row variances
+
+These rotation methods optimize the variance of columns and/or rows of
+the squared loadings matrix. The methods differ by how much weight is
+assigned to the column and row variances.
+
+```@docs
+CrawfordFerguson
+Oblimin
+Biquartimax
+Biquartimin
+Equamax
+Oblimax
+Parsimax
+Quartimax
+Varimax
+```
+
+### Other
+
+```@docs
+Geomin
+Infomax
 MinimumEntropy
 MinimumEntropyRatio
-Oblimax
-Oblimin
-Parsimax
 PatternSimplicity
-Quartimax
 Simplimax
 TandemCriteria
 TandemCriterionI
 TandemCriterionII
 TargetRotation
-Varimax
 ```
 
 ## User Interface

--- a/docs/src/rotation_methods.md
+++ b/docs/src/rotation_methods.md
@@ -6,7 +6,7 @@ Let us consider the *p×k* factor loadings matrix *L* for *p* variables and *k* 
 Most of the rotation methods aim to find the full-rank *k×k* rotation matrix *U*,
 so that the rotated loadings matrix *Λ = L × U* optimizes the given *criterion* function *Q(Λ)*.
 
-## Orthogonal methods
+## [Orthogonal methods](@id rotation_orthogonal)
 
 *Orthogonal* criteria restrict the rotation matrix *U* to be orthogonal.
 
@@ -33,7 +33,7 @@ so that the rotated loadings matrix *Λ = L × U* optimizes the given *criterion
 | [`TargetRotation`](@ref)      |                                      |
 | [`Varimax`](@ref)             | [kaiser1958](@citet)                 | equivalent to `Oblimin(gamma = 1, orthogonal = true)`   |
 
-## Oblique methods
+## [Oblique methods](@id rotation_oblique)
 
 *Oblique* criteria allow the rotation matrix *U* to be an arbitrary full-rank *k×k* matrix.
 

--- a/docs/src/rotation_methods.md
+++ b/docs/src/rotation_methods.md
@@ -8,7 +8,7 @@ so that the rotated loadings matrix *Λ = L × U* optimizes the given *criterion
 
 ## [Orthogonal methods](@id rotation_orthogonal)
 
-*Orthogonal* criteria restrict the rotation matrix *U* to be orthogonal.
+*Orthogonal* criteria restrict the rotation matrix *U* to be orthogonal (``U⋅Uᵀ = I``).
 
 | criterion                     | reference                            | note                                                    |
 | ----------------------------- | ------------------------------------ | ------------------------------------------------------- |
@@ -35,7 +35,10 @@ so that the rotated loadings matrix *Λ = L × U* optimizes the given *criterion
 
 ## [Oblique methods](@id rotation_oblique)
 
-*Oblique* criteria allow the rotation matrix *U* to be an arbitrary full-rank *k×k* matrix.
+*Oblique* criteria allow the rotation matrix *R* to be any full-rank *k×k* matrix.
+*Oblique* rotations do not preserve the orthogonality of the factors.
+To preserve the loadings matrix *communalities* (``c_i = ∑_{j=1}^k L_{i,j}²``),
+the oblique rotation matrix *R* has to satisfy ``\mathrm{diag} (R⋅Rᵀ) = I``.
 
 | criterium                   | reference                            | note                                              |
 | --------------------------- | ------------------------------------ | ------------------------------------------------- |

--- a/docs/src/rotation_methods.md
+++ b/docs/src/rotation_methods.md
@@ -2,8 +2,8 @@
 
 *FactorRotations.jl* implements multiple *orthogonal* and *oblique* rotation methods.
 
-Let us consider the *p*-by-*k* factor loadings matrix *L* for *p* variables and *k* factors.
-Most of the rotation methods aim to find the full-rank *k*-by-*k* rotation matrix *U*,
+Let us consider the *p×k* factor loadings matrix *L* for *p* variables and *k* factors.
+Most of the rotation methods aim to find the full-rank *k×k* rotation matrix *U*,
 so that the rotated loadings matrix *Λ = L × U* optimizes the given *criterion* function *Q(Λ)*.
 
 ## Orthogonal methods
@@ -35,7 +35,7 @@ so that the rotated loadings matrix *Λ = L × U* optimizes the given *criterion
 
 ## Oblique methods
 
-*Oblique* criteria allow the rotation matrix *U* to be an arbitrary full-rank *k*-by-*k* matrix.
+*Oblique* criteria allow the rotation matrix *U* to be an arbitrary full-rank *k×k* matrix.
 
 | criterium                   | reference                            | note                                              |
 | --------------------------- | ------------------------------------ | ------------------------------------------------- |

--- a/src/methods/biquartimax.jl
+++ b/src/methods/biquartimax.jl
@@ -1,10 +1,10 @@
 """
     Biquartimax()
 
-The Biquartimax rotation method.
+The *Biquartimax* rotation method.
 
 ## Details
-The Biquartimax rotation method is a special case of the [`Oblimin`](@ref) rotation with
+The *Biquartimax* rotation method is a special case of the [`Oblimin`](@ref) rotation with
 parameters `gamma = 0.5` and `orthogonal = true`.
 
 ## Examples

--- a/src/methods/biquartimin.jl
+++ b/src/methods/biquartimin.jl
@@ -1,10 +1,10 @@
 """
     Biquartimin
 
-The Biquartimin rotation criterion.
+The *Biquartimin* rotation criterion.
 
 # Keyword arguments
-- `orthogonal`: orthogonal: If orthogonal = true an orthogonal rotation is performed, an
+- `orthogonal`: If `true`, an orthogonal rotation is performed, an
                 oblique rotation otherwise. (default: `false`)
 """
 struct Biquartimin{RT} <: RotationMethod{RT}

--- a/src/methods/component_loss.jl
+++ b/src/methods/component_loss.jl
@@ -1,9 +1,26 @@
 """
     AbstractComponentLoss{RT} <: RotationMethod{RT}
 
-An abstract type representing component loss functions.
+An abstract type representing rotation criterions based
+on component-wise loss functions.
 
-Implementing a custom component loss `T` requires that `T <: AbstractComponentLoss`.
+## Details
+The *component loss* factor rotation minimizes the sum of losses
+across all elements of the factor loading matrix *Λ*:
+
+```math
+Q(Λ) = ∑_{i, j} h(λ_{i,j}).
+```
+
+Custom component loss methods have to be inherited from `AbstractComponentLoss`.
+
+## See also
+
+- [`ComponentLoss`](@ref) for the implementation that accepts a user-defined loss function.
+- [`KatzRohlf`](@ref)
+- [`LinearRightConstant`](@ref)
+- [`Concave`](@ref)
+- [`Absolmin`](@ref)
 """
 abstract type AbstractComponentLoss{RT} <: RotationMethod{RT} end
 
@@ -18,20 +35,12 @@ end
 """
     ComponentLoss(loss::Function; orthogonal = false)
 
-A generic implementation of the component loss factor rotation method.
-`loss` defines the loss function that is applied to the components of the loading matrix.
+A generic implementation of the [component loss](@ref AbstractComponentLoss) factor rotation method
+with the user-defined `loss` function that is applied to each element of the loading matrix.
 
 ## Keyword arguments
 - `orthogonal`: If `orthogonal = true` an orthogonal rotation is performed, an oblique
    rotation otherwise. (default: `false`)
-
-## Details
-The component loss factor rotation applies a loss function to each element of the factor
-loading matrix. Then the following criterion is minimized:
-
-```math
-Q(\\Lambda) = \\sum_i \\sum_j h(\\lambda_{ij})
-```
 
 ## Examples
 ### Quartimax as a component loss
@@ -78,7 +87,7 @@ end
 """
     KatzRohlf(bandwidth)
 
-A component loss criterion with loss function
+A [component loss](@ref AbstractComponentLoss) criterion with the loss function
 
 ```math
 h(\\lambda) = 1 - \\exp\\left(-\\left(\\frac{\\lambda}{b}\\right)^2\\right),
@@ -99,13 +108,13 @@ end
 """
     LinearRightConstant(bandwidth)
 
-The linear right constant component loss factor rotation criterion.
+The linear right constant [component loss](@ref AbstractComponentLoss) factor rotation criterion.
 It has the loss function
 
 ```math
 h(\\lambda) = \\begin{cases}
     (\\frac{\\lambda}{b})^2&\\text{if } |\\lambda| \\leq b \\\\
-    1 &\\text{if } \\lambda > b,
+    1 &\\text{if } |\\lambda| > b,
 \\end{cases}
 ```
 
@@ -124,7 +133,7 @@ end
 """
     Concave(bandwidth = 1)
 
-The simple concave component loss factor rotation criterion.
+The simple concave [component loss](@ref AbstractComponentLoss) factor rotation criterion.
 It has the loss function
 
 ```math
@@ -146,7 +155,7 @@ end
 """
     Absolmin(epsilon)
 
-The Absolmin component loss factor rotation criterion.
+The Absolmin [component loss](@ref AbstractComponentLoss) factor rotation criterion.
 It has the loss function
 
 ```math

--- a/src/methods/component_loss.jl
+++ b/src/methods/component_loss.jl
@@ -81,10 +81,10 @@ end
 A component loss criterion with loss function
 
 ```math
-h(\\lambda) = 1 - \\exp\\left(-\\left(\\frac{\\lambda}{b}\\right)^2\\right)
+h(\\lambda) = 1 - \\exp\\left(-\\left(\\frac{\\lambda}{b}\\right)^2\\right),
 ```
 
-where ``b`` is the bandwidth parameter.
+where ``b`` is the *bandwidth* parameter.
 """
 struct KatzRohlf{F} <: AbstractComponentLoss{Orthogonal}
     bandwidth::Float64
@@ -105,11 +105,11 @@ It has the loss function
 ```math
 h(\\lambda) = \\begin{cases}
     (\\frac{\\lambda}{b})^2&\\text{if } |\\lambda| \\leq b \\\\
-    1 &\\text{if } \\lambda > b
+    1 &\\text{if } \\lambda > b,
 \\end{cases}
 ```
 
-where ``b`` is the bandwidth parameter.
+where ``b`` is the *bandwidth* parameter.
 """
 struct LinearRightConstant{F} <: AbstractComponentLoss{Orthogonal}
     bandwidth::Float64
@@ -128,10 +128,10 @@ The simple concave component loss factor rotation criterion.
 It has the loss function
 
 ```math
-h(\\lambda) = 1 - \\exp(-\\frac{|\\lambda|}{b})
+h(\\lambda) = 1 - \\exp(-\\frac{|\\lambda|}{b}),
 ```
 
-where ``b`` is the bandwidth parameter.
+where ``b`` is the *bandwidth* parameter.
 """
 struct Concave{F} <: AbstractComponentLoss{Oblique}
     bandwidth::Float64
@@ -150,7 +150,7 @@ The Absolmin component loss factor rotation criterion.
 It has the loss function
 
 ```math
-h(\\lambda) = |\\lambda|
+h(\\lambda) = |\\lambda|.
 ```
 """
 struct Absolmin{F} <: AbstractComponentLoss{Oblique}

--- a/src/methods/crawford_ferguson.jl
+++ b/src/methods/crawford_ferguson.jl
@@ -9,9 +9,25 @@ The family of *Crawford-Ferguson* rotation methods.
                 oblique rotation otherwise. (default: `false`)
 
 ## Details
-The Crawford-Ferguson family allows both orthogonal and oblique rotation of the
-*p*×*k* factor loading matrix. If orthogonal rotation is performed, Crawford-Ferguson with
-a specific value for `kappa` is equivalent to the following rotation methods:
+The *Crawford-Ferguson* family allows both orthogonal and oblique rotation of the
+factor loading matrix with the following criterion:
+
+```math
+\\begin{aligned}
+Q_{\\mathrm{CF}}(Λ, ϰ) &=
+    \\frac{1 - ϰ}{4} \\left⟨Λ², Λ²⋅\\left(1^{k×k} - I\\right) \\right⟩ +
+    \\frac{ϰ}{4} \\left⟨Λ², (1^{p×p} - I)⋅Λ²\\right⟩ = \\\\
+  &\\hspace{4em} = -\\frac{1 - ϰ}{4} k ∑_{i=1}^p \\mathrm{Var}(Λ²_{i, \\cdot})
+    - \\frac{ϰ}{4} p ∑_{j=1}^k \\mathrm{Var}(Λ²_{⋅, j}) = \\\\
+  &\\hspace{8em} = \\frac{1 - ϰ}{4} ∑_{i=1}^p \\left(∑_{j=1}^k λ_{i,j}² \\right)²
+    + \\frac{ϰ}{4} ∑_{j=1}^k \\left(∑_{i=1}^p λ_{i,j}² \\right)²
+    - \\frac{1}{4} ∑_{i,j} λ⁴_{i,j}.
+\\end{aligned}
+```
+
+If the rotation is *orthogonal*, the *communalities* (``c_i = ∑_{j=1}^k λ_{i,j}²``)
+are preserved, and, for a specific `kappa`, Crawford-Ferguson criterion becomes equivalent
+to the following rotation methods:
 - *ϰ = γ/p*: [`Oblimin(gamma = γ, orthogonal = true)`](@ref Oblimin)
 - *ϰ = 0*: [`Quartimax`](@ref)
 - *ϰ = 1/p*: [`Varimax`](@ref)

--- a/src/methods/crawford_ferguson.jl
+++ b/src/methods/crawford_ferguson.jl
@@ -1,7 +1,7 @@
 """
     CrawfordFerguson(; kappa, orthogonal = false)
 
-The family of Crawford-Ferguson rotation methods.
+The family of *Crawford-Ferguson* rotation methods.
 
 ## Keyword arguments
 - `kappa`: The parameter determining the rotation criterion (see *Details*).

--- a/src/methods/crawford_ferguson.jl
+++ b/src/methods/crawford_ferguson.jl
@@ -12,12 +12,12 @@ The family of *Crawford-Ferguson* rotation methods.
 The Crawford-Ferguson family allows both orthogonal and oblique rotation of the
 *p*×*k* factor loading matrix. If orthogonal rotation is performed, Crawford-Ferguson with
 a specific value for `kappa` is equivalent to the following rotation methods:
-- *κ = γ/p*: [`Oblimin(gamma = γ, orthogonal = true)`](@ref Oblimin)
-- *κ = 0*: [`Quartimax`](@ref)
-- *κ = 1/p*: [`Varimax`](@ref)
-- *κ = k/2p*: [`Equamax`](@ref)
-- *κ = (k - 1)/(p + k - 2)*: [`Parsimax`](@ref)
-- *κ = 1*: Factor parsimony
+- *ϰ = γ/p*: [`Oblimin(gamma = γ, orthogonal = true)`](@ref Oblimin)
+- *ϰ = 0*: [`Quartimax`](@ref)
+- *ϰ = 1/p*: [`Varimax`](@ref)
+- *ϰ = k/2p*: [`Equamax`](@ref)
+- *ϰ = (k - 1)/(p + k - 2)*: [`Parsimax`](@ref)
+- *ϰ = 1*: Factor parsimony
 
 ## Examples
 ```jldoctest

--- a/src/methods/geomin.jl
+++ b/src/methods/geomin.jl
@@ -3,8 +3,17 @@
 
 The *Geomin* rotation method.
 
+## Details
+The *Geomin* is an oblique rotation method that minimizes the
+sum of column-wise geometric means of the squared loadings:
+
+```math
+Q_{\\mathrm{Geomin}}(Λ, ε) =
+    ∑_{i = 1}^p \\left(\\prod_{j = 1}^k λ²_{i, j} + ε \\right)^{\\frac{1}{k}}.
+```
+
 ## Keyword arguments
-- `epsilon`: A small constant to deal with zero loadings.
+- `epsilon`: A small non-negative constant to deal with zero loadings.
 """
 struct Geomin{T} <: RotationMethod{Oblique}
     ε::T

--- a/src/methods/geomin.jl
+++ b/src/methods/geomin.jl
@@ -1,7 +1,7 @@
 """
     Geomin(epsilon = 0.01)
 
-The Geomin rotation method.
+The *Geomin* rotation method.
 
 ## Keyword arguments
 - `epsilon`: A small constant to deal with zero loadings.

--- a/src/methods/infomax.jl
+++ b/src/methods/infomax.jl
@@ -1,7 +1,23 @@
 """
     Infomax(; orthogonal = false)
 
-The Infomax rotation method.
+The *Infomax* rotation method.
+
+## Details
+
+The *Infomax* method maximizes the mutual information between the variables and factors:
+
+```math
+\\begin{aligned}
+Q_{\\mathrm{Infomax}}(Λ) =& \\left(∑_{i,j} λ_{i,j}²\\right)^{-1} \\left(
+    - ∑_{i,j} λ_{i,j}² \\log λ_{i,j}²
+    + ∑_{i=1}^p \\left(∑_{j=1}^k λ_{i,j}²\\right) \\log ∑_{j=1}^k λ_{i,j}² + \\right. \\\\
+    & \\hspace{8em} \\left.
+    + ∑_{j=1}^k \\left(∑_{i=1}^p λ_{i,j}²\\right) \\log ∑_{i=1}^p λ_{i,j}²
+    - \\log k
+    \\right).
+\\end{aligned}
+```
 
 ## Keyword arguments
 - `orthogonal`: If `orthogonal = true` an orthogonal rotation is performed, an oblique

--- a/src/methods/minimum_entropy.jl
+++ b/src/methods/minimum_entropy.jl
@@ -3,6 +3,14 @@
 
 The *Minimum Entropy* rotation method.
 
+## Details
+
+The *Minimum Entropy* rotation method minimizes the *entropy* of the squared loadings:
+
+```math
+Q_{\\mathrm{MinEnt}}(Λ) = -\\frac{1}{2} ∑_{i,j} λ_{i,j}² \\log λ_{i,j}².
+```
+
 ## See also
 
 [`MinimumEntropyRatio`](@ref)

--- a/src/methods/minimum_entropy.jl
+++ b/src/methods/minimum_entropy.jl
@@ -1,7 +1,11 @@
 """
     MinimumEntropy()
 
-The Minimum Entropy rotation method.
+The *Minimum Entropy* rotation method.
+
+## See also
+
+[`MinimumEntropyRatio`](@ref)
 """
 struct MinimumEntropy <: RotationMethod{Orthogonal} end
 

--- a/src/methods/minimum_entropy_ratio.jl
+++ b/src/methods/minimum_entropy_ratio.jl
@@ -1,7 +1,11 @@
 """
     MinimumEntropyRatio()
 
-The Minimum Entropy Ratio rotation method.
+The *Minimum Entropy Ratio* rotation method.
+
+## See also
+
+[`MinimumEntropy`](@ref)
 """
 struct MinimumEntropyRatio <: RotationMethod{Orthogonal} end
 

--- a/src/methods/oblimax.jl
+++ b/src/methods/oblimax.jl
@@ -1,14 +1,14 @@
 """
     Oblimax(; orthogonal = false)
 
-The Oblimax rotation method.
+The *Oblimax* rotation method.
 
 ## Keyword arguments
 - `orthogonal`: If `orthogonal = true` an orthogonal rotation is performed, an oblique
    rotation otherwise. (default: `false`)
 
 ## Details
-The Oblimax rotation method is equivalent to [`Quartimax`](@ref) for orthogonal rotation.
+The *Oblimax* rotation method is equivalent to [`Quartimax`](@ref) for orthogonal rotation.
 
 ## Examples
 ```jldoctest; filter = r"(\\d*)\\.(\\d{4})\\d+" => s"\\1.\\2"

--- a/src/methods/oblimin.jl
+++ b/src/methods/oblimin.jl
@@ -42,4 +42,4 @@ struct Oblimin{T,V} <: RotationMethod{T}
 end
 
 criterion_and_gradient!(∇Q::OptionalGradient, method::Oblimin, Λ::AbstractMatrix{<:Real}) =
-    weighted_sums_criterion_and_gradient!(∇Q, Λ, 1 - method.γ, method.γ / size(Λ, 1))
+    weighted_sums_criterion_and_gradient!(∇Q, Λ, 1, method.γ / size(Λ, 1))

--- a/src/methods/oblimin.jl
+++ b/src/methods/oblimin.jl
@@ -12,7 +12,7 @@ The family of *Oblimin* rotation methods.
 The *Oblimin* rotation family allows orthogonal as well as oblique rotation of the *p*×*k* factor
 loading matrix. If orthogonal rotation is performed, *Oblimin* is equivalent to the following
 rotation methods given a value for `gamma`:
-- *γ = p×κ*: [`CrawfordFerguson(kappa = κ, orthogonal = true)`](@ref CrawfordFerguson)
+- *γ = p×ϰ*: [`CrawfordFerguson(kappa = ϰ, orthogonal = true)`](@ref CrawfordFerguson)
 - *γ = 0*: [`Quartimax`](@ref)
 - *γ = 1/2*: [`Biquartimax`](@ref)
 - *γ = 1*: [`Varimax`](@ref)

--- a/src/methods/oblimin.jl
+++ b/src/methods/oblimin.jl
@@ -9,8 +9,22 @@ The family of *Oblimin* rotation methods.
    rotation otherwise. (default: `false`)
 
 ## Details
-The *Oblimin* rotation family allows orthogonal as well as oblique rotation of the *p*×*k* factor
-loading matrix. If orthogonal rotation is performed, *Oblimin* is equivalent to the following
+The *Oblimin* rotation family allows orthogonal as well as oblique rotation that
+minimizes the following criterion:
+
+```math
+\\begin{aligned}
+Q_{\\mathrm{oblimin}}(Λ, γ) =&
+    \\frac{1}{4} \\left⟨Λ², \\left(I - \\frac{γ}{p} 1^{p\\times p}\\right) ⋅
+                             Λ² ⋅ \\left(1^{k\\times k} - I\\right) \\right⟩ = \\\\
+  & = \\frac{1}{4} ∑_{i=1}^p \\left(∑_{j=1}^k λ²_{i, j}\\right)²
+    + \\frac{γ}{4p} ∑_{j=1}^k \\left(∑_{i=1}^p λ²_{i, j}\\right)²
+    - \\frac{γ}{4p} \\left(∑_{i, j} λ²_{i, j}\\right)²
+    - \\frac{1}{4} ∑_{i, j} λ⁴_{i, j}.
+\\end{aligned}
+```
+
+If orthogonal rotation is performed, *Oblimin* is equivalent to the following
 rotation methods given a value for `gamma`:
 - *γ = p×ϰ*: [`CrawfordFerguson(kappa = ϰ, orthogonal = true)`](@ref CrawfordFerguson)
 - *γ = 0*: [`Quartimax`](@ref)

--- a/src/methods/oblimin.jl
+++ b/src/methods/oblimin.jl
@@ -24,6 +24,10 @@ Q_{\\mathrm{oblimin}}(Λ, γ) =&
 \\end{aligned}
 ```
 
+Note that this criterion definition is given for the case of rotations that preserve
+the loading matrix *communalities* (see [oblique rotation](@ref rotation_oblique)).
+It does not apply for arbitrary rotation matrices.
+
 If orthogonal rotation is performed, *Oblimin* is equivalent to the following
 rotation methods given a value for `gamma`:
 - *γ = p×ϰ*: [`CrawfordFerguson(kappa = ϰ, orthogonal = true)`](@ref CrawfordFerguson)

--- a/src/methods/parsimax.jl
+++ b/src/methods/parsimax.jl
@@ -2,7 +2,7 @@
     Parsimax()
 
 *Parsimax* is an orthogonal rotation method, which is equivalent to [`CrawfordFerguson`](@ref)
-rotation of *p × k* loadings matrix *Λ* with ``\\kappa = \\frac{k - 1}{p + k - 2}``.
+rotation of *p × k* loadings matrix *Λ* with ``ϰ = \\frac{k - 1}{p + k - 2}``.
 """
 struct Parsimax <: RotationMethod{Orthogonal} end
 

--- a/src/methods/pattern_simplicity.jl
+++ b/src/methods/pattern_simplicity.jl
@@ -3,6 +3,15 @@
 
 The *Pattern Simplicity* factor rotation criterion.
 
+## Details
+
+```math
+Q_{\\mathrm{PS}}(Λ) = \\log \\left\\| \\mathrm{diag}\\left(\\left(Λ²\\right)ᵀ ⋅ Λ²\\right) \\right\\| -
+                      \\log \\left\\| \\left(Λ²\\right)ᵀ ⋅ Λ² \\right\\|,
+```
+
+where ``Λ²`` is the matrix of squared loadings.
+
 ## Keyword arguments
 - `orthogonal`: If `orthogonal = true` an orthogonal rotation is performed, an oblique
    rotation otherwise. (default: `false`)

--- a/src/methods/pattern_simplicity.jl
+++ b/src/methods/pattern_simplicity.jl
@@ -1,7 +1,7 @@
 """
     PatternSimplicity(; orthogonal = false)
 
-The Pattern Simplicity factor rotation criterion.
+The *Pattern Simplicity* factor rotation criterion.
 
 ## Keyword arguments
 - `orthogonal`: If `orthogonal = true` an orthogonal rotation is performed, an oblique

--- a/src/methods/quartimax.jl
+++ b/src/methods/quartimax.jl
@@ -1,10 +1,10 @@
 """
     Quartimax()
 
-The Quartimax rotation criterion.
+The *Quartimax* rotation criterion.
 
 ## Details
-The Quartimax criterion is a special case of the [`Oblimin`](@ref) rotation criterion with
+The *Quartimax* criterion is a special case of the [`Oblimin`](@ref) rotation criterion with
 parameter `gamma = 0`.
 
 ## Examples

--- a/src/methods/simplimax.jl
+++ b/src/methods/simplimax.jl
@@ -1,7 +1,7 @@
 """
     Simplimax(; m::Int)
 
-The Simplimax rotation method.
+The *Simplimax* rotation method.
 """
 struct Simplimax <: RotationMethod{Oblique}
     m::Int

--- a/src/methods/target_rotation.jl
+++ b/src/methods/target_rotation.jl
@@ -8,12 +8,26 @@ The (partial) target rotation criterion.
    rotation otherwise. (default: `false`)
 
 ## Details
-Target rotation rotates a factor loading matrix towards the target matrix, `target`.
-For a fully specified `target` matrix (e.g. all entries in the matrix are numbers), full
-target rotation is performed.
+The method rotates a factor loading matrix ``Λ ∈ ℝ^{p×k}`` towards the `target` matrix
+``T ∈ ℝ^{p×k}``.
+For a fully specified `target` matrix (e.g. all its entries are numbers),
+the method tries to make the rotated loading matrix as similar to the `target`
+as possible:
 
-Partially specified target rotation can be achieved setting the unspecified entries in the
-`target` matrix to `missing`.
+```math
+Q_T(Λ) = \\frac{1}{2} \\left\\| Λ - T \\right\\|^2.
+```
+
+When some of the `target` matrix elements are `missing` instead of being finite numbers,
+the *partially specified* target rotation is performed.
+In that case the criterion becomes
+
+```math
+Q_{WT}(Λ) = \\frac{1}{2} \\left\\| (Λ - T) ⋅ W \\right\\|^2,
+```
+
+where ``W ∈ ℝ^{p×k}`` is a weight matrix that has *1* for non-missing
+elements of *T* and *0* otherwise.
 
 ## Examples
 ### Full target rotation

--- a/src/methods/varimax.jl
+++ b/src/methods/varimax.jl
@@ -4,7 +4,13 @@
 The *Varimax* rotation criterion.
 
 ## Details
-The *Varimax* is an orthogonal rotation method that maximizes the column variances of the loading matrix.
+The *Varimax* is an orthogonal rotation method that maximizes the column variances of
+the loading matrix ``Λ ∈ ℝ^{p × k}``:
+
+```math
+Q(Λ) = -\\frac{p}{4} ∑_{j=1}^{k} \\mathrm{Var}_i(Λ_{i, j}).
+```
+
 It is a special case of the [`Oblimin`](@ref) rotation criterion with parameter
 `gamma = 1`.
 


### PR DESCRIPTION
Add the rotation criterion formulas for the majority of rotation methods.
It seems, there's not enough open access papers/resources on that.
The most comprehensive that I have found is [Stata Doc](https://www.stata.com/manuals13/mvrotatemat.pdf), which I used as one of the references.
The PR will make *FactorRotations.jl* documentation a useful resource on factor rotations by itself. :)

In particular, the formulas are added to *Oblimin* and *CrawfordFerguson* families,
which highlighted the bug in the *Oblimin* implementation: instead of accounting for the `abs2(∑_ij Λ_ij²)`, it was using `∑_j abs2(∑_i Λ_ij²)`.
That was/is not captured in the unit tests, because it is only relevant for oblique rotations.
Plus, *Oblimin* requires that the rotation matrix preserves *communalities* (does not seem to be the case for Crawford-Ferguson),
so using it directly as a regularization term in the optimization problems leads to degenerated solutions.

So with the math formulas it should be also easier to understand and check their implementation.